### PR TITLE
feat: sync lang attribute with language switch

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -79,10 +79,11 @@ async function initI18n() {
   try {
     const res = await fetch('./assets/data/i18n.json');
     const translations = await res.json();
-    // Set default language to English on initial load
-    let currentLang = 'en';
+    // Initialize language from <html lang> or fall back to English
+    let currentLang = document.documentElement.getAttribute('lang') || 'en';
 
     function applyTranslations() {
+      document.documentElement.setAttribute('lang', currentLang);
       document.querySelectorAll('[data-i18n]').forEach(el => {
         const key = el.getAttribute('data-i18n');
         const text = translations[currentLang][key];

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- default document language is now Chinese
- keep `<html lang>` in sync with selected interface language

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03c28a028832fb7fd7821169f98fa